### PR TITLE
Documentation generation fix: Season calendar

### DIFF
--- a/docs/data/2017_F1.htm
+++ b/docs/data/2017_F1.htm
@@ -114,7 +114,7 @@ Support series:
 <li class="toclevel-2 tocsection-4"><a href="#Mid-season_changes"><span class="tocnumber">1.3</span> <span class="toctext">Mid-season changes</span></a></li>
 </ul>
 </li>
-<li class="toclevel-1 tocsection-5"><a href="#Season_calendar"><span class="tocnumber">2</span> <span class="toctext">Season calendar</span></a>
+<li class="toclevel-1 tocsection-5"><a href="#Calendar"><span class="tocnumber">2</span> <span class="toctext">Season calendar</span></a>
 <ul>
 <li class="toclevel-2 tocsection-6"><a href="#Calendar_changes"><span class="tocnumber">2.1</span> <span class="toctext">Calendar changes</span></a></li>
 </ul>
@@ -386,7 +386,7 @@ Support series:
 <li>In the week before the <a href="/wiki/2017_Malaysian_Grand_Prix" title="2017 Malaysian Grand Prix">Malaysian Grand Prix</a>, <a href="/wiki/Daniil_Kvyat" title="Daniil Kvyat">Daniil Kvyat</a> was stood down by <a href="/wiki/Scuderia_Toro_Rosso" title="Scuderia Toro Rosso">Toro Rosso</a>, making way for GP2 Series champion <a href="/wiki/Pierre_Gasly" title="Pierre Gasly">Pierre Gasly</a>.<sup id="cite_ref-62" class="reference"><a href="#cite_note-62">[58]</a></sup> Kvyat will return to the team for the <a href="/wiki/2017_United_States_Grand_Prix" title="2017 United States Grand Prix">United States Grand Prix</a>.<sup id="cite_ref-63" class="reference"><a href="#cite_note-63">[59]</a></sup></li>
 <li><a href="/wiki/Carlos_Sainz_Jr." title="Carlos Sainz Jr.">Carlos Sainz Jr.</a> left Toro Rosso after the <a href="/wiki/2017_Japanese_Grand_Prix" title="2017 Japanese Grand Prix">Japanese Grand Prix</a>. He is scheduled to move to <a href="/wiki/Renault_in_Formula_One" title="Renault in Formula One">Renault</a>, where he is planned to replace <a href="/wiki/Jolyon_Palmer" title="Jolyon Palmer">Jolyon Palmer</a>.<sup id="cite_ref-RenaultSainz17_39-1" class="reference"><a href="#cite_note-RenaultSainz17-39">[35]</a></sup></li>
 </ul>
-<h2><span class="mw-headline" id="Season_calendar">Season calendar</span></h2>
+<h2><span class="mw-headline" id="Calendar">Season calendar</span></h2>
 <div class="thumb tright">
 <div class="thumbinner" style="width:292px;"><a href="/wiki/File:Formula_1_all_over_the_world-2017.svg" class="image"><img alt="" src="//upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Formula_1_all_over_the_world-2017.svg/290px-Formula_1_all_over_the_world-2017.svg.png" width="290" height="128" class="thumbimage" srcset="//upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Formula_1_all_over_the_world-2017.svg/435px-Formula_1_all_over_the_world-2017.svg.png 1.5x, //upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Formula_1_all_over_the_world-2017.svg/580px-Formula_1_all_over_the_world-2017.svg.png 2x" data-file-width="940" data-file-height="415" /></a>
 <div class="thumbcaption">

--- a/docs/library/HtmlProvider.fsx
+++ b/docs/library/HtmlProvider.fsx
@@ -66,7 +66,7 @@ The `Load` method allows reading the data from a file or web resource. We could 
 The following sample calls the `Load` method with an URL that points to a live version of the same page on wikipedia.
 *)
 // Download the table for the 2017 F1 calendar from Wikipedia
-let f1Calendar = F1_2017.Load(F1_2017_URL).Tables.``Season calendar``
+let f1Calendar = F1_2017.Load(F1_2017_URL).Tables.Calendar
 
 // Look at the top row, being the first race of the calendar
 let firstRow = f1Calendar.Rows |> Seq.head

--- a/docs/library/JsonProvider.fsx
+++ b/docs/library/JsonProvider.fsx
@@ -306,7 +306,7 @@ let doc = WorldBank.GetSample()
 (** Note that we can also load the data directly from the web both in the `Load` method and in
 the type provider sample parameter, and there's an asynchronous `AsyncLoad` method available too: *)
 let wbReq =
-    "http://api.worldbank.org/country/cz/indicator/"
+    "https://api.worldbank.org/country/cz/indicator/"
     + "GC.DOD.TOTL.GD.ZS?format=json"
 
 let docAsync = WorldBank.AsyncLoad(wbReq)

--- a/docs/library/JsonValue.fsx
+++ b/docs/library/JsonValue.fsx
@@ -147,7 +147,7 @@ let value = JsonValue.Load(__SOURCE_DIRECTORY__ + "../../data/WorldBank.json")
 asynchronous version available too: *)
 
 let wbReq =
-    "http://api.worldbank.org/country/cz/indicator/"
+    "https://api.worldbank.org/country/cz/indicator/"
     + "GC.DOD.TOTL.GD.ZS?format=json"
 
 let valueAsync = JsonValue.AsyncLoad(wbReq)

--- a/src/FSharp.Data.DesignTime/WorldBank/WorldBankProvider.fs
+++ b/src/FSharp.Data.DesignTime/WorldBank/WorldBankProvider.fs
@@ -28,7 +28,7 @@ type public WorldBankProvider(cfg: TypeProviderConfig) as this =
     let asm = System.Reflection.Assembly.GetExecutingAssembly()
     let ns = "FSharp.Data"
 
-    let defaultServiceUrl = "http://api.worldbank.org/v2"
+    let defaultServiceUrl = "https://api.worldbank.org/v2"
     let cacheDuration = TimeSpan.FromDays 30.0
     let restCache = createInternetFileCache "WorldBankSchema" cacheDuration
 

--- a/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
+++ b/tests/FSharp.Data.DesignTime.Tests/expected/WorldBank,World Development Indicators;Global Financial Development,True.expected
@@ -1,6 +1,6 @@
 class WorldBankDataProvider : obj
     static member GetDataContext: () -> WorldBankDataProvider+ServiceTypes+WorldBankDataService
-    (new WorldBankData("http://api.worldbank.org", "World Development Indicators;Global Financial Development"))
+    (new WorldBankData("https://api.worldbank.org", "World Development Indicators;Global Financial Development"))
 
 
 class WorldBankDataProvider+ServiceTypes : obj


### PR DESCRIPTION
The data-source has changed, the calendar id has changed from season_calendar to calendar, and that's why current documentation generation fails. This PR fixes that.
